### PR TITLE
npx run scripts 内の gatsby は npx のものを使う、npm run clean を用意する

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
         "develop": "npx gatsby develop",
         "build": "npx gatsby build",
         "serve": "npx gatsby serve",
-        "format": "npx prettier --write 'src/**/*.js'"
+        "format": "npx prettier --write 'src/**/*.js'",
+        "clean": "rm -rf node_modules public .cache/ jspm_packages/"
     },
     "devDependencies": {
         "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
         "typeface-montserrat": "^1.1.13"
     },
     "scripts": {
-        "develop": "gatsby develop",
-        "build": "gatsby build",
-        "serve": "gatsby serve",
-        "format": "prettier --write 'src/**/*.js'"
+        "develop": "npx gatsby develop",
+        "build": "npx gatsby build",
+        "serve": "npx gatsby serve",
+        "format": "npx prettier --write 'src/**/*.js'"
     },
     "devDependencies": {
         "prettier": "^2.2.1",


### PR DESCRIPTION
SSIA、ガンガン修正や文句を言ってください〜

# 背景
現在の npm run script の gatsby の呼び出し方はグローバルのものに依存していて、開発者によってgatsby-cliのバージョンが異なる場合があるので npx gatsby で叩いたものを使用した方が良いです

# やったこと
packages.json を編集した

# 意図している挙動
グローバルからgatsby-cliを消して動けば良い