### PR TITLE
feat: Writeup一覧のソートに利用する条件を追加

### DIFF
--- a/pages/ctf/TsukuCTF2021/index.tsx
+++ b/pages/ctf/TsukuCTF2021/index.tsx
@@ -76,7 +76,17 @@ const TsukuCTF = ({
         <h2>Writeups</h2>
         <ul>
           {allPostsData
-            .sort((a, b) => (a.genre > b.genre ? 1 : -1))
+            // ソートの第一条件をジャンル、第二条件をidでソートすることで、並び順を一意にする
+            // このソート順にしたのは、ユーザがみた時にジャンル->問題名のアルファベット順で探すと思ったため
+            .sort((a, b) =>
+              a.genre === b.genre
+                ? a.id < b.id
+                  ? -1
+                  : 1
+                : a.genre < b.genre
+                ? -1
+                : 1
+            )
             .map(({ id, title, description, author, genre, solver, point }) => (
               <Link href={`/ctf/${ctfId}/${id}`} key={id} passHref>
                 <a>

--- a/pages/ctf/TsukuCTF2022/index.tsx
+++ b/pages/ctf/TsukuCTF2022/index.tsx
@@ -100,7 +100,17 @@ const TsukuCTF = ({
         <h2>Writeups</h2>
         <ul>
           {allPostsData
-            .sort((a, b) => (a.genre > b.genre ? 1 : -1))
+            // ソートの第一条件をジャンル、第二条件をidでソートすることで、並び順を一意にする
+            // このソート順にしたのは、ユーザがみた時にジャンル->問題名のアルファベット順で探すと思ったため
+            .sort((a, b) =>
+              a.genre === b.genre
+                ? a.id < b.id
+                  ? -1
+                  : 1
+                : a.genre < b.genre
+                ? -1
+                : 1
+            )
             .map(({ id, title, description, author, genre, solver, point }) => (
               <Link href={`/ctf/${ctfId}/${id}`} key={id} passHref>
                 <a>


### PR DESCRIPTION
## 概要
現状の実装ではWriteup一覧をソートする際にジャンル名のみを利用している。その結果、順序性が一意に定まらない。実際に、https://fans.sechack365.com/ctf/TsukuCTF2022 でこの現象が起きている。


https://user-images.githubusercontent.com/29667656/197897181-b98cf3f5-9acd-425a-a5e5-830308980644.mov

この現象を解消するために、問題順のソート条件としてジャンル名だけでなく問題名も利用することで、記事の順序性を一意に定まるようにする。